### PR TITLE
Impl std error

### DIFF
--- a/src/binary_search.rs
+++ b/src/binary_search.rs
@@ -28,8 +28,7 @@
 
 use std::cmp::Ordering;
 
-pub fn binary_search<F: Fn(usize) -> Ordering>(start: usize, end: usize, cmp: F) -> Option<usize>
-{
+pub fn binary_search<F: Fn(usize) -> Ordering>(start: usize, end: usize, cmp: F) -> Option<usize> {
     if start >= end {
         return None;
     }
@@ -38,7 +37,7 @@ pub fn binary_search<F: Fn(usize) -> Ordering>(start: usize, end: usize, cmp: F)
     match cmp(mid) {
         Ordering::Greater => binary_search(start, mid, cmp),
         Ordering::Equal => Some(mid),
-        Ordering::Less => binary_search(mid + 1, end, cmp)
+        Ordering::Less => binary_search(mid + 1, end, cmp),
     }
 }
 
@@ -50,7 +49,11 @@ fn test_binary_search() {
     assert_eq!(binary_search(30, 50, |x| x.cmp(&42)), Some(42));
     assert_eq!(binary_search(300, 500, |x| x.cmp(&42)), None);
     assert_eq!(
-        binary_search(0, 500, |x| if x < 42 { Ordering::Less } else { Ordering::Greater }),
+        binary_search(0, 500, |x| if x < 42 {
+            Ordering::Less
+        } else {
+            Ordering::Greater
+        }),
         None
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,26 +28,22 @@
 
 use time::{OffsetDateTime, PrimitiveDateTime, UtcOffset};
 
-pub trait Offset
-{
+pub trait Offset {
     fn to_utc(&self) -> UtcOffset;
     fn name(&self) -> &str;
 }
 
-pub trait TimeZone
-{
+pub trait TimeZone {
     type Offset: Offset;
     fn get_offset_utc(&self, date_time: &OffsetDateTime) -> Self::Offset;
     fn name(&self) -> &str;
 }
 
-pub trait OffsetDateTimeExt
-{
+pub trait OffsetDateTimeExt {
     fn to_timezone<T: TimeZone>(&self, tz: &T) -> OffsetDateTime;
 }
 
-pub trait PrimitiveDateTimeExt
-{
+pub trait PrimitiveDateTimeExt {
     fn assume_timezone<T: TimeZone>(&self, tz: &T) -> OffsetDateTime;
 }
 
@@ -65,9 +61,9 @@ impl OffsetDateTimeExt for OffsetDateTime {
     }
 }
 
+mod binary_search;
 mod timezone_impl;
 pub mod timezones;
-mod binary_search;
 
 #[cfg(feature = "system")]
 pub mod system;
@@ -76,13 +72,13 @@ pub use timezone_impl::Tz;
 
 #[cfg(test)]
 mod tests {
+    use crate::timezones;
+    use crate::Offset;
+    use crate::OffsetDateTimeExt;
+    use crate::PrimitiveDateTimeExt;
+    use crate::TimeZone;
     use time::macros::datetime;
     use time::OffsetDateTime;
-    use crate::PrimitiveDateTimeExt;
-    use crate::OffsetDateTimeExt;
-    use crate::timezones;
-    use crate::TimeZone;
-    use crate::Offset;
 
     #[test]
     fn names() {

--- a/src/system.rs
+++ b/src/system.rs
@@ -26,13 +26,12 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use std::fmt::{Display, Formatter};
 use crate::timezones::get_by_name;
 use crate::Tz;
+use std::fmt::{Display, Formatter};
 
 #[derive(Debug)]
-pub enum Error
-{
+pub enum Error {
     /// An IO error has occurred.
     Io(std::io::Error),
 
@@ -47,11 +46,10 @@ pub enum Error
     Unicode,
 
     /// The timezone doesn't exist in the crate's database.
-    Unknown
+    Unknown,
 }
 
-impl std::error::Error for Error {
-}
+impl std::error::Error for Error {}
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -60,7 +58,7 @@ impl Display for Error {
             Error::Os => f.write_str("low-level os error"),
             Error::Undetermined => f.write_str("undefined timezone"),
             Error::Unicode => f.write_str("timezone name is not unicode"),
-            Error::Unknown => f.write_str("unknown timezone name")
+            Error::Unknown => f.write_str("unknown timezone name"),
         }
     }
 }
@@ -79,7 +77,7 @@ pub fn get_timezone() -> Result<&'static Tz, Error> {
                 return Err(Error::Undetermined);
             }
         } else {
-			unsafe {
+            unsafe {
                 use windows_sys::Win32::System::Time::GetDynamicTimeZoneInformation;
                 use windows_sys::Win32::System::Time::DYNAMIC_TIME_ZONE_INFORMATION;
                 let mut data: DYNAMIC_TIME_ZONE_INFORMATION = std::mem::zeroed();
@@ -94,14 +92,14 @@ pub fn get_timezone() -> Result<&'static Tz, Error> {
                     while win_name_utf16[len] != 0x0 {
                         len += 1;
                     }
-					if len == 0 {
-						return Err(Error::Undetermined);
-					}
+                    if len == 0 {
+                        return Err(Error::Undetermined);
+                    }
                     let win_tz = String::from_utf16(&win_name_utf16[..len]).map_err(|_| Error::Unicode)?;
-					let tz = get_by_name(&win_tz).ok_or(Error::Unknown)?;
+                    let tz = get_by_name(&win_tz).ok_or(Error::Unknown)?;
                     return Ok(tz);
                 }
-			}
+            }
         }
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -50,6 +50,9 @@ pub enum Error
     Unknown
 }
 
+impl std::error::Error for Error {
+}
+
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/timezone_impl.rs
+++ b/src/timezone_impl.rs
@@ -26,17 +26,17 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::binary_search::binary_search;
+use crate::{Offset, TimeZone};
 use std::cmp::Ordering;
 use std::ops::Index;
-use crate::binary_search::binary_search;
 use time::{OffsetDateTime, UtcOffset};
-use crate::{Offset, TimeZone};
 
 //Inspired from https://github.com/chronotope/chrono-tz/blob/main/src/timezone_impl.rs
 
 struct Span {
     start: Option<i64>,
-    end: Option<i64>
+    end: Option<i64>,
 }
 
 impl Span {
@@ -62,11 +62,10 @@ pub struct FixedTimespan {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct FixedTimespanSet
-{
+pub struct FixedTimespanSet {
     pub name: &'static str,
     pub first: FixedTimespan,
-    pub others: &'static [(i64, FixedTimespan)]
+    pub others: &'static [(i64, FixedTimespan)],
 }
 
 impl FixedTimespanSet {
@@ -77,7 +76,7 @@ impl FixedTimespanSet {
     fn span_utc(&self, i: usize) -> Span {
         let start = match i {
             0 => None,
-            _ => Some(self.others[i - 1].0)
+            _ => Some(self.others[i - 1].0),
         };
         let end;
         if i >= self.others.len() {
@@ -96,15 +95,14 @@ impl Index<usize> for FixedTimespanSet {
         debug_assert!(index < self.len());
         match index {
             0 => &self.first,
-            _ => &self.others[index - 1].1
+            _ => &self.others[index - 1].1,
         }
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct TzOffset
-{
-    timespan: &'static FixedTimespan
+pub struct TzOffset {
+    timespan: &'static FixedTimespan,
 }
 
 impl Offset for TzOffset {
@@ -119,7 +117,7 @@ impl Offset for TzOffset {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Tz {
-    set: &'static FixedTimespanSet
+    set: &'static FixedTimespanSet,
 }
 
 impl TimeZone for Tz {
@@ -127,10 +125,10 @@ impl TimeZone for Tz {
 
     fn get_offset_utc(&self, date_time: &OffsetDateTime) -> TzOffset {
         let timestamp = date_time.unix_timestamp();
-        let index = binary_search(0, self.set.len(),
-                                  |i| self.set.span_utc(i).cmp(timestamp)).unwrap();
+        let index =
+            binary_search(0, self.set.len(), |i| self.set.span_utc(i).cmp(timestamp)).unwrap();
         TzOffset {
-            timespan: &self.set[index]
+            timespan: &self.set[index],
         }
     }
 

--- a/src/timezones.rs
+++ b/src/timezones.rs
@@ -26,12 +26,12 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::timezone_impl::internal_tz_new;
 use crate::timezone_impl::FixedTimespan;
 use crate::timezone_impl::FixedTimespanSet;
-use crate::timezone_impl::internal_tz_new;
 
-use phf::Map;
 use crate::Tz;
+use phf::Map;
 
 include!(concat!(env!("OUT_DIR"), "/timezones.rs"));
 
@@ -39,7 +39,11 @@ pub fn find_by_name(name: &str) -> Vec<&'static Tz> {
     if let Some(list) = WIN_TIMEZONES.get(name) {
         list.iter().map(|v| *v).collect()
     } else {
-        TIMEZONES.entries().filter(|(k, _)| k.contains(name)).map(|(_, v)| *v).collect()
+        TIMEZONES
+            .entries()
+            .filter(|(k, _)| k.contains(name))
+            .map(|(_, v)| *v)
+            .collect()
     }
 }
 


### PR DESCRIPTION
Thank you for the amazing crate!
This PR consists of two commits:
The first commit of the change implements `std::error::Error` for `Error` type so that it's easier for users to propagate the error returned by `time-tz`.
The second commit is a result of `cargo fmt`, as I noticed there are some formatting issues like mixed tab-indentations and spaces-indentations.