### PR TITLE
Fix assume timezone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,7 @@ serde-xml-rs = "0.5.1"
 serde = { version = "1.0.136", features = ["derive"] }
 
 [features]
-system = ["windows-sys", "thiserror"]
-posix-tz = ["nom", "thiserror"]
+default = ["db"]
+system = ["windows-sys", "thiserror", "db"]
+posix-tz = ["nom", "thiserror", "db"]
+db = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-tz"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["Yuri Edward <yuri6037@outlook.com>"]
 description = "Implementation of tz database (IANA) for time Rust crate."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "time-tz"
-version = "1.0.0-alpha-1"
+version = "1.0.0"
 edition = "2021"
 authors = ["Yuri Edward <yuri6037@outlook.com>"]
-description = "Implementation of tz database (IANA) for time Rust crate."
+description = "Implementation of tz database (IANA) for the time Rust crate."
 license = "BSD-3-Clause"
 repository = "https://github.com/Yuri6037/time-tz"
 readme = "./README.MD"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-tz"
-version = "0.7.0"
+version = "1.0.0-alpha-1"
 edition = "2021"
 authors = ["Yuri Edward <yuri6037@outlook.com>"]
 description = "Implementation of tz database (IANA) for time Rust crate."

--- a/README.MD
+++ b/README.MD
@@ -32,7 +32,7 @@ fn main()
     // The function returns None if the timezone doesn't exist.
 
     // Now we can create a primitive date time and call the extension function:
-    let dt = datetime!(2016-10-8 17:0:0).assume_timezone(london);
+    let dt = datetime!(2016-10-8 17:0:0).assume_timezone_utc(london);
 
 
     // ===========================

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,0 +1,147 @@
+// Copyright (c) 2022, Yuri6037
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+// * Neither the name of time-tz nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use time::{OffsetDateTime, UtcOffset};
+
+/// This trait represents a particular timezone offset.
+pub trait Offset {
+    /// Converts this timezone offset to a [UtcOffset](time::UtcOffset).
+    fn to_utc(&self) -> UtcOffset;
+
+    /// Returns the name of this offset.
+    fn name(&self) -> &str;
+
+    /// Returns true if this offset is DST in the corresponding timezone, false otherwise.
+    fn is_dst(&self) -> bool;
+}
+
+/// This trait represents a timezone provider.
+pub trait TimeZone {
+    /// The type of offset.
+    type Offset: Offset;
+
+    /// Search for the given date time offset (assuming it is UTC) in this timezone.
+    fn get_offset_utc(&self, date_time: &OffsetDateTime) -> Self::Offset;
+
+    /// Search for the given date time offset (assuming it is already local) in this timezone.
+    fn get_offset_local(&self, date_time: &OffsetDateTime) -> OffsetResult<Self::Offset>;
+
+    /// Gets the main/default offset in this timezone.
+    fn get_offset_primary(&self) -> Self::Offset;
+
+    /// Returns the name of this timezone.
+    fn name(&self) -> &str;
+}
+
+/// This represents the possible types of errors when trying to find a local offset.
+#[derive(Clone, Copy, Debug)]
+pub enum OffsetResult<T> {
+    /// The date time is not ambiguous (exactly 1 is possible).
+    Some(T),
+
+    /// The date time is ambiguous (2 are possible).
+    Ambiguous(T, T),
+
+    /// The date time is invalid.
+    None,
+}
+
+impl<T> OffsetResult<T> {
+    /// Unwraps this OffsetResult assuming ambiguity is an error.
+    pub fn unwrap(self) -> T {
+        match self {
+            OffsetResult::Some(v) => v,
+            OffsetResult::Ambiguous(_, _) => panic!("Attempt to unwrap an ambiguous offset"),
+            OffsetResult::None => panic!("Attempt to unwrap an invalid offset"),
+        }
+    }
+
+    /// Unwraps this OffsetResult resolving ambiguity by taking the first result.
+    pub fn unwrap_first(self) -> T {
+        match self {
+            OffsetResult::Some(v) => v,
+            OffsetResult::Ambiguous(v, _) => v,
+            OffsetResult::None => panic!("Attempt to unwrap an invalid offset"),
+        }
+    }
+
+    /// Unwraps this OffsetResult resolving ambiguity by taking the second result.
+    pub fn unwrap_second(self) -> T {
+        match self {
+            OffsetResult::Some(v) => v,
+            OffsetResult::Ambiguous(_, v) => v,
+            OffsetResult::None => panic!("Attempt to unwrap an invalid offset"),
+        }
+    }
+
+    /// Turns this OffsetResult into an Option assuming ambiguity is an error.
+    pub fn take(self) -> Option<T> {
+        match self {
+            OffsetResult::Some(v) => Some(v),
+            OffsetResult::Ambiguous(_, _) => None,
+            OffsetResult::None => None,
+        }
+    }
+
+    /// Turns this OffsetResult into an Option resolving ambiguity by taking the first result.
+    pub fn take_first(self) -> Option<T> {
+        match self {
+            OffsetResult::Some(v) => Some(v),
+            OffsetResult::Ambiguous(v, _) => Some(v),
+            OffsetResult::None => None,
+        }
+    }
+
+    /// Turns this OffsetResult into an Option resolving ambiguity by taking the second result.
+    pub fn take_second(self) -> Option<T> {
+        match self {
+            OffsetResult::Some(v) => Some(v),
+            OffsetResult::Ambiguous(_, v) => Some(v),
+            OffsetResult::None => None,
+        }
+    }
+
+    /// Returns true if this OffsetResult is None.
+    pub fn is_none(&self) -> bool {
+        match self {
+            OffsetResult::Some(_) => false,
+            OffsetResult::Ambiguous(_, _) => false,
+            OffsetResult::None => true,
+        }
+    }
+
+    /// Returns true if this OffsetResult is ambiguous.
+    pub fn is_ambiguous(&self) -> bool {
+        match self {
+            OffsetResult::Some(_) => false,
+            OffsetResult::Ambiguous(_, _) => true,
+            OffsetResult::None => false,
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub enum OffsetResult<T> {
     Ambiguous(T, T),
 
     /// The date time is invalid.
-    None
+    None,
 }
 
 impl<T> OffsetResult<T> {
@@ -60,7 +60,7 @@ impl<T> OffsetResult<T> {
         match self {
             OffsetResult::Some(v) => v,
             OffsetResult::Ambiguous(_, _) => panic!("Attempt to unwrap an ambiguous offset"),
-            OffsetResult::None => panic!("Attempt to unwrap an invalid offset")
+            OffsetResult::None => panic!("Attempt to unwrap an invalid offset"),
         }
     }
 
@@ -69,7 +69,7 @@ impl<T> OffsetResult<T> {
         match self {
             OffsetResult::Some(v) => v,
             OffsetResult::Ambiguous(v, _) => v,
-            OffsetResult::None => panic!("Attempt to unwrap an invalid offset")
+            OffsetResult::None => panic!("Attempt to unwrap an invalid offset"),
         }
     }
 
@@ -78,7 +78,7 @@ impl<T> OffsetResult<T> {
         match self {
             OffsetResult::Some(v) => v,
             OffsetResult::Ambiguous(_, v) => v,
-            OffsetResult::None => panic!("Attempt to unwrap an invalid offset")
+            OffsetResult::None => panic!("Attempt to unwrap an invalid offset"),
         }
     }
 
@@ -87,7 +87,7 @@ impl<T> OffsetResult<T> {
         match self {
             OffsetResult::Some(v) => Some(v),
             OffsetResult::Ambiguous(_, _) => None,
-            OffsetResult::None => None
+            OffsetResult::None => None,
         }
     }
 
@@ -96,7 +96,7 @@ impl<T> OffsetResult<T> {
         match self {
             OffsetResult::Some(v) => Some(v),
             OffsetResult::Ambiguous(v, _) => Some(v),
-            OffsetResult::None => None
+            OffsetResult::None => None,
         }
     }
 
@@ -105,7 +105,7 @@ impl<T> OffsetResult<T> {
         match self {
             OffsetResult::Some(v) => Some(v),
             OffsetResult::Ambiguous(_, v) => Some(v),
-            OffsetResult::None => None
+            OffsetResult::None => None,
         }
     }
 
@@ -114,7 +114,7 @@ impl<T> OffsetResult<T> {
         match self {
             OffsetResult::Some(_) => false,
             OffsetResult::Ambiguous(_, _) => false,
-            OffsetResult::None => true
+            OffsetResult::None => true,
         }
     }
 
@@ -123,7 +123,7 @@ impl<T> OffsetResult<T> {
         match self {
             OffsetResult::Some(_) => false,
             OffsetResult::Ambiguous(_, _) => true,
-            OffsetResult::None => false
+            OffsetResult::None => false,
         }
     }
 }
@@ -182,8 +182,11 @@ impl PrimitiveDateTimeExt for PrimitiveDateTime {
     fn assume_timezone<T: TimeZone>(&self, tz: &T) -> OffsetResult<OffsetDateTime> {
         match tz.get_offset_local(&self.assume_utc()) {
             OffsetResult::Some(a) => OffsetResult::Some(self.assume_offset(a.to_utc())),
-            OffsetResult::Ambiguous(a, b) => OffsetResult::Ambiguous(self.assume_offset(a.to_utc()), self.assume_offset(b.to_utc())),
-            OffsetResult::None => OffsetResult::None
+            OffsetResult::Ambiguous(a, b) => OffsetResult::Ambiguous(
+                self.assume_offset(a.to_utc()),
+                self.assume_offset(b.to_utc()),
+            ),
+            OffsetResult::None => OffsetResult::None,
         }
     }
 
@@ -274,7 +277,9 @@ mod tests {
     #[test]
     fn handles_forward_changeover() {
         assert_eq!(
-            datetime!(2022-03-27 01:30).assume_timezone(timezones::db::CET).unwrap(),
+            datetime!(2022-03-27 01:30)
+                .assume_timezone(timezones::db::CET)
+                .unwrap(),
             datetime!(2022-03-27 01:30 +01:00)
         );
     }
@@ -282,25 +287,33 @@ mod tests {
     #[test]
     fn handles_after_changeover() {
         assert_eq!(
-            datetime!(2022-03-27 03:30).assume_timezone(timezones::db::CET).unwrap(),
+            datetime!(2022-03-27 03:30)
+                .assume_timezone(timezones::db::CET)
+                .unwrap(),
             datetime!(2022-03-27 03:30 +02:00)
         );
     }
 
     #[test]
     fn handles_broken_time() {
-        assert!(datetime!(2022-03-27 02:30).assume_timezone(timezones::db::CET).is_none());
+        assert!(datetime!(2022-03-27 02:30)
+            .assume_timezone(timezones::db::CET)
+            .is_none());
     }
 
     #[test]
     fn handles_backward_changeover() {
         // During backward changeover, the hour between 02:00 and 03:00 occurs twice, so either answer is correct
         assert_eq!(
-            datetime!(2022-10-30 02:30).assume_timezone(timezones::db::CET).unwrap_first(),
+            datetime!(2022-10-30 02:30)
+                .assume_timezone(timezones::db::CET)
+                .unwrap_first(),
             datetime!(2022-10-30 02:30 +02:00)
         );
         assert_eq!(
-            datetime!(2022-10-30 02:30).assume_timezone(timezones::db::CET).unwrap_second(),
+            datetime!(2022-10-30 02:30)
+                .assume_timezone(timezones::db::CET)
+                .unwrap_second(),
             datetime!(2022-10-30 02:30 +01:00)
         );
     }

--- a/src/timezone_impl.rs
+++ b/src/timezone_impl.rs
@@ -27,7 +27,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::binary_search::binary_search;
-use crate::{Offset, TimeZone};
+use crate::{Offset, OffsetResult, TimeZone};
 use std::cmp::Ordering;
 use std::ops::Index;
 use time::{OffsetDateTime, UtcOffset};
@@ -40,6 +40,16 @@ struct Span {
 }
 
 impl Span {
+    fn contains(&self, x: i64) -> bool {
+        match (self.start, self.end) {
+            (Some(a), Some(b)) if a <= x && x < b => true,
+            (Some(a), None) if a <= x => true,
+            (None, Some(b)) if b > x => true,
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
     fn cmp(&self, x: i64) -> Ordering {
         match (self.start, self.end) {
             (Some(a), Some(b)) if a <= x && x < b => Ordering::Equal,
@@ -82,6 +92,22 @@ impl FixedTimespanSet {
             None
         } else {
             Some(self.others[i].0)
+        };
+        Span { start, end }
+    }
+
+    fn span_local(&self, i: usize) -> Span {
+        let start = match i {
+            0 => None,
+            _ => Some(&self.others[i - 1])
+        }.map(|(i, v)| i + v.utc_offset + v.dst_offset);
+        let end = if i >= self.others.len() {
+            None
+        } else if i == 0 {
+            Some(&self.others[i].0 + self.first.utc_offset + self.first.dst_offset)
+        } else {
+            let (_, v) = &self.others[i - 1];
+            Some(self.others[i].0 + v.utc_offset + v.dst_offset)
         };
         Span { start, end }
     }
@@ -134,6 +160,37 @@ impl TimeZone for Tz {
         TzOffset {
             timespan: &self.set[index],
         }
+    }
+
+    fn get_offset_local(&self, date_time: &OffsetDateTime) -> OffsetResult<Self::Offset> {
+        let timestamp = date_time.unix_timestamp();
+        if let Some(i) = binary_search(0, self.set.len(), |i| self.set.span_local(i).cmp(timestamp)) {
+            return if self.set.len() == 1 {
+                OffsetResult::Some(TzOffset { timespan: &self.set[i] })
+            } else if i == 0 && self.set.span_local(1).contains(timestamp) {
+                OffsetResult::Ambiguous(
+                    TzOffset { timespan: &self.set[0] },
+                    TzOffset { timespan: &self.set[1] }
+                )
+            } else if i == 0 {
+                OffsetResult::Some(TzOffset { timespan: &self.set[0] })
+            } else if self.set.span_local(i - 1).contains(timestamp) {
+                OffsetResult::Ambiguous(
+                    TzOffset { timespan: &self.set[i - 1] },
+                    TzOffset { timespan: &self.set[i] }
+                )
+            } else if i == self.set.len() - 1 {
+                OffsetResult::Some(TzOffset { timespan: &self.set[i] })
+            } else if self.set.span_local(i + 1).contains(timestamp) {
+                OffsetResult::Ambiguous(
+                    TzOffset { timespan: &self.set[i] },
+                    TzOffset { timespan: &self.set[i + 1] }
+                )
+            } else {
+                OffsetResult::Some(TzOffset { timespan: &self.set[i] })
+            }
+        }
+        OffsetResult::None
     }
 
     fn get_offset_primary(&self) -> Self::Offset {

--- a/src/timezone_impl.rs
+++ b/src/timezone_impl.rs
@@ -99,8 +99,9 @@ impl FixedTimespanSet {
     fn span_local(&self, i: usize) -> Span {
         let start = match i {
             0 => None,
-            _ => Some(&self.others[i - 1])
-        }.map(|(i, v)| i + v.utc_offset + v.dst_offset);
+            _ => Some(&self.others[i - 1]),
+        }
+        .map(|(i, v)| i + v.utc_offset + v.dst_offset);
         let end = if i >= self.others.len() {
             None
         } else if i == 0 {
@@ -164,31 +165,52 @@ impl TimeZone for Tz {
 
     fn get_offset_local(&self, date_time: &OffsetDateTime) -> OffsetResult<Self::Offset> {
         let timestamp = date_time.unix_timestamp();
-        if let Some(i) = binary_search(0, self.set.len(), |i| self.set.span_local(i).cmp(timestamp)) {
+        if let Some(i) = binary_search(0, self.set.len(), |i| self.set.span_local(i).cmp(timestamp))
+        {
             return if self.set.len() == 1 {
-                OffsetResult::Some(TzOffset { timespan: &self.set[i] })
+                OffsetResult::Some(TzOffset {
+                    timespan: &self.set[i],
+                })
             } else if i == 0 && self.set.span_local(1).contains(timestamp) {
                 OffsetResult::Ambiguous(
-                    TzOffset { timespan: &self.set[0] },
-                    TzOffset { timespan: &self.set[1] }
+                    TzOffset {
+                        timespan: &self.set[0],
+                    },
+                    TzOffset {
+                        timespan: &self.set[1],
+                    },
                 )
             } else if i == 0 {
-                OffsetResult::Some(TzOffset { timespan: &self.set[0] })
+                OffsetResult::Some(TzOffset {
+                    timespan: &self.set[0],
+                })
             } else if self.set.span_local(i - 1).contains(timestamp) {
                 OffsetResult::Ambiguous(
-                    TzOffset { timespan: &self.set[i - 1] },
-                    TzOffset { timespan: &self.set[i] }
+                    TzOffset {
+                        timespan: &self.set[i - 1],
+                    },
+                    TzOffset {
+                        timespan: &self.set[i],
+                    },
                 )
             } else if i == self.set.len() - 1 {
-                OffsetResult::Some(TzOffset { timespan: &self.set[i] })
+                OffsetResult::Some(TzOffset {
+                    timespan: &self.set[i],
+                })
             } else if self.set.span_local(i + 1).contains(timestamp) {
                 OffsetResult::Ambiguous(
-                    TzOffset { timespan: &self.set[i] },
-                    TzOffset { timespan: &self.set[i + 1] }
+                    TzOffset {
+                        timespan: &self.set[i],
+                    },
+                    TzOffset {
+                        timespan: &self.set[i + 1],
+                    },
                 )
             } else {
-                OffsetResult::Some(TzOffset { timespan: &self.set[i] })
-            }
+                OffsetResult::Some(TzOffset {
+                    timespan: &self.set[i],
+                })
+            };
         }
         OffsetResult::None
     }

--- a/src/timezone_impl.rs
+++ b/src/timezone_impl.rs
@@ -105,7 +105,7 @@ impl FixedTimespanSet {
         let end = if i >= self.others.len() {
             None
         } else if i == 0 {
-            Some(&self.others[i].0 + self.first.utc_offset + self.first.dst_offset)
+            Some(self.others[i].0 + self.first.utc_offset + self.first.dst_offset)
         } else {
             let (_, v) = &self.others[i - 1];
             Some(self.others[i].0 + v.utc_offset + v.dst_offset)

--- a/src/timezone_impl.rs
+++ b/src/timezone_impl.rs
@@ -136,6 +136,12 @@ impl TimeZone for Tz {
         }
     }
 
+    fn get_offset_primary(&self) -> Self::Offset {
+        TzOffset {
+            timespan: &self.set.first,
+        }
+    }
+
     fn name(&self) -> &str {
         self.set.name
     }

--- a/update_repo.sh
+++ b/update_repo.sh
@@ -1,2 +1,2 @@
 curl https://raw.githubusercontent.com/unicode-org/cldr/main/common/supplemental/windowsZones.xml > win_cldr_data/windowsZones.xml
-cd tz && git pull && cd ..
+cd tz && git checkout main && git pull && cd ..


### PR DESCRIPTION
This PR finally fixes the behavior of `assume_timezone` and `assume_timezone_utc`. The `assume_timezone` function is now fixed to always assume the input `PrimitiveDateTime` is already in the target timezone. The `assume_timezone_utc` preserves the old behavior of assuming the input `PrimitiveDateTime` is actually in UTC.

Fixes #5 
Fixes #6 