### PR TITLE
Fixed wrong handling of GetDynamicTimeZoneInformation

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -73,9 +73,7 @@ pub fn get_timezone() -> Result<&'static Tz, Error> {
                 use windows_sys::Win32::System::Time::DYNAMIC_TIME_ZONE_INFORMATION;
                 let mut data: DYNAMIC_TIME_ZONE_INFORMATION = std::mem::zeroed();
                 let res = GetDynamicTimeZoneInformation(&mut data as _);
-                if res == 0 {
-                    return Err(Error::Undetermined);
-                } else if res != 1 && res != 2 {
+                if res > 2 {
                     return Err(Error::Os);
                 } else {
                     let win_name_utf16 = &data.TimeZoneKeyName;


### PR DESCRIPTION
`get_timezone()` always returns `Error::Undetermined` unless summer time is used in the current locale.

According to [Documentation](https://docs.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-getdynamictimezoneinformation#return-value):

> ## Return value
> If the function succeeds, it returns one of the following values.
> | Return code/value | Description |
> |-|-|
> | TIME_ZONE_ID_UNKNOWN 0 | Daylight saving time is not used in the current time zone, because there are no transition dates. |

Code 0 means success so you have to return the fetched timezone instead of `Error::Undetermined`.
