### PR TITLE
Bump `phf` and `phf_codegen` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["date-and-time"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-phf = "0.10.1"
+phf = "0.11.1"
 time = { version = "0.3.7", features = ["macros"] }
 cfg-if = "1.0.0"
 
@@ -25,7 +25,7 @@ windows-sys = { version = "0.32.0", features = ["Win32_System_Time", "Win32_Foun
 
 [build-dependencies]
 parse-zoneinfo = { version = "0.3" }
-phf_codegen = "0.10.0"
+phf_codegen = "0.11.1"
 serde-xml-rs = "0.5.1"
 serde = { version = "1.0.136", features = ["derive"] }
 


### PR DESCRIPTION
I'm working on a feature for Quickwit that depends on this crate and noticed that I was now depending on two versions of `phf`.

As far as testing goes, I build the project and run the test suite locally.